### PR TITLE
ci: bump nais/fasit-deploy to v4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,8 +85,8 @@ jobs:
             helm push "$chart" oci://${{ env.GOOGLE_REGISTRY }}/nais-io/nais/feature
           done
 
-  rollout:
-    name: Rollout
+  deploy:
+    name: Deploy
     if: github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/main'
     needs:
       - build
@@ -95,7 +95,14 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: nais/fasit-deploy@v2 # ratchet:exclude
+      - uses: nais/fasit-deploy@v4 # ratchet:exclude
         with:
           chart: oci://${{ env.GOOGLE_REGISTRY }}/nais-io/nais/feature/${{ env.FEATURE }}
           version: ${{ needs.build.outputs.version }}
+          targets: |
+            [
+              { "target": { "kind": "tenant", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "onprem", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "tenant", "tenant": "nav" } },
+              { "target": { "kind": "onprem", "tenant": "nav" } }
+            ]


### PR DESCRIPTION
Migrate from `nais/fasit-deploy@v2` (rollouts) to `@v4` (deployments).

- Bump action to floating `@v4` (preserving existing `ratchet:exclude`).
- Add explicit `targets:` list. `Feature.yaml` declares `environmentKinds: [legacy, tenant, onprem]`; `legacy` is dropped (not a real env-kind in Fasit). Narrowed to `tenant: nav` for the broad targets — this feature is nav-only.
- Rename `rollout` job → `deploy` to match the deployment concept.